### PR TITLE
Fix panic handling in cookies manager

### DIFF
--- a/api/api_test.go
+++ b/api/api_test.go
@@ -50,8 +50,10 @@ func TestAuthMiddleware(t *testing.T) {
 	ctx.SetCache(cache)
 	ctx.SetLogger(logging.NewLogger(os.Stdout, os.Stderr))
 
-	cookies := cookies.NewManager("/tmp/test_plakar")
-	ctx.SetCookies(cookies)
+	cookieManager, err := cookies.NewManager("/tmp/test_plakar")
+	require.NoError(t, err)
+	defer cookieManager.Close()
+	ctx.SetCookies(cookieManager)
 	ctx.Client = "plakar-test/1.0.0"
 
 	lstore, err := storage.Create(ctx.GetInner(), map[string]string{"location": "mock:///test/location"}, wrappedConfig)
@@ -110,8 +112,10 @@ func Test_UnknownEndpoint(t *testing.T) {
 	ctx.SetCache(cache)
 	ctx.SetLogger(logging.NewLogger(os.Stdout, os.Stderr))
 
-	cookies := cookies.NewManager("/tmp/test_plakar")
-	ctx.SetCookies(cookies)
+	cookieManager, err := cookies.NewManager("/tmp/test_plakar")
+	require.NoError(t, err)
+	defer cookieManager.Close()
+	ctx.SetCookies(cookieManager)
 	ctx.Client = "plakar-test/1.0.0"
 
 	lstore, err := storage.Create(ctx.GetInner(), map[string]string{"location": "mock:///test/location"}, wrappedConfig)

--- a/cookies/cookies.go
+++ b/cookies/cookies.go
@@ -15,17 +15,17 @@ type Manager struct {
 	cookiesDir string
 }
 
-func NewManager(cookiesDir string) *Manager {
+func NewManager(cookiesDir string) (*Manager, error) {
 	cookiesDir = filepath.Join(cookiesDir, "cookies", COOKIES_VERSION)
 	if err := os.MkdirAll(cookiesDir, 0700); err != nil {
-		panic(fmt.Errorf("cannot create cookies directory: %w", err))
+		return nil, fmt.Errorf("cannot create cookies directory: %w", err)
 	}
 	if err := os.Chmod(cookiesDir, 0700); err != nil {
-		panic(fmt.Errorf("cannot set permissions for cookies directory: %w", err))
+		return nil, fmt.Errorf("cannot set permissions for cookies directory: %w", err)
 	}
 	return &Manager{
 		cookiesDir: cookiesDir,
-	}
+	}, nil
 }
 
 func (m *Manager) Close() error {

--- a/main.go
+++ b/main.go
@@ -173,7 +173,12 @@ func entryPoint() int {
 		return 1
 	}
 
-	ctx.SetCookies(cookies.NewManager(cookiesDir))
+	cookieManager, err := cookies.NewManager(cookiesDir)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%s: could not initialize cookies manager: %s\n", flag.CommandLine.Name(), err)
+		return 1
+	}
+	ctx.SetCookies(cookieManager)
 	defer ctx.GetCookies().Close()
 
 	if opt_agentless {

--- a/testing/repository.go
+++ b/testing/repository.go
@@ -34,10 +34,11 @@ func GenerateRepository(t *testing.T, bufout *bytes.Buffer, buferr *bytes.Buffer
 		os.RemoveAll(tmpRepoDirRoot)
 	})
 
-	cookies := cookies.NewManager(tmpCacheDir)
+	cookiesManager, err := cookies.NewManager(tmpCacheDir)
+	require.NoError(t, err)
 
 	ctx := appcontext.NewAppContext()
-	ctx.SetCookies(cookies)
+	ctx.SetCookies(cookiesManager)
 
 	ctx.Client = "plakar-test/1.0.0"
 
@@ -121,10 +122,11 @@ func GenerateRepositoryWithoutConfig(t *testing.T, bufout *bytes.Buffer, buferr 
 		os.RemoveAll(tmpRepoDirRoot)
 	})
 
-	cookies := cookies.NewManager(tmpCacheDir)
+	cookiesManager, err := cookies.NewManager(tmpCacheDir)
+	require.NoError(t, err)
 
 	ctx := appcontext.NewAppContext()
-	ctx.SetCookies(cookies)
+	ctx.SetCookies(cookiesManager)
 	ctx.Client = "plakar-test/1.0.0"
 	ctx.MaxConcurrency = 1
 


### PR DESCRIPTION
## Summary
- return an error from cookies.NewManager when directory setup fails
- wire the constructor error through main and testing helpers
- extend cookies tests to cover error conditions

## Testing
- go test ./...
